### PR TITLE
Return a success exit code

### DIFF
--- a/packages/fontagon-cli/lib/generate.js
+++ b/packages/fontagon-cli/lib/generate.js
@@ -56,7 +56,7 @@ function separatedSvg (path) {
 module.exports = (...args) => {
   return generate(...args)
     .then((opts) => {
-      process.exit(1)
+      process.exit(0)
     })
     .catch((err) => {
       // stopSpinner(false) // do not persist


### PR DESCRIPTION
I think you want to return a `0` exit code here.  _Without_ this change I was getting this error despite the build succeeding:

![image](https://user-images.githubusercontent.com/77567/136637152-2c477977-3b4c-42b1-b17e-a27a4466c380.png)
